### PR TITLE
Allow to use not inline template

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -44,12 +44,20 @@ class Component
             throw new Exception('Second argument for vue directive must be an associtive array');
         }
 
-        return (new static)
-            ->setAttribute('inline-template')
+        $isInlineTemplate = !(array_has($attributes, 'inline-template') && array_get($attributes,
+                'inline-template') === false);
+
+        $component = (new static)
             ->setAttribute('v-cloak')
             ->setAttribute('is', $name)
             ->setAttributes($attributes)
             ->getStartTag();
+        
+        if($isInlineTemplate){
+            $component->setAttribute('inline-template');
+        }
+        
+        return $component;
     }
 
     /**

--- a/src/Component.php
+++ b/src/Component.php
@@ -50,14 +50,13 @@ class Component
         $component = (new static)
             ->setAttribute('v-cloak')
             ->setAttribute('is', $name)
-            ->setAttributes($attributes)
-            ->getStartTag();
+            ->setAttributes($attributes);
         
         if($isInlineTemplate){
             $component->setAttribute('inline-template');
         }
         
-        return $component;
+        return $component->getStartTag();
     }
 
     /**


### PR DESCRIPTION
Useful when using the directive to pass PHP data as property to the single file component.