### PR TITLE
Fix for upgrade to Laravel 5.8

### DIFF
--- a/src/DirectiveServiceProvider.php
+++ b/src/DirectiveServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Jhoff\BladeVue;
 
 use Jhoff\BladeVue\Directives\Basic;
-use Illuminate\Support\Facades\Blade;
 use Jhoff\BladeVue\Directives\Inline;
 use Illuminate\Support\ServiceProvider;
 
@@ -23,19 +22,21 @@ class DirectiveServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Blade::directive('vue', function ($expression) {
+        app('view');
+
+        app('blade.compiler')->directive('vue', function ($expression) {
             return Basic::start($expression);
         });
 
-        Blade::directive('endvue', function () {
+        app('blade.compiler')->directive('endvue', function () {
             return Basic::end();
         });
 
-        Blade::directive('inlinevue', function ($expression) {
+        app('blade.compiler')->directive('inlinevue', function ($expression) {
             return Inline::start($expression);
         });
 
-        Blade::directive('endinlinevue', function () {
+        app('blade.compiler')->directive('endinlinevue', function () {
             return Inline::end();
         });
     }


### PR DESCRIPTION
Addresses #2 

Testing: Installed into 5.8 app successfully. ran `./vendor/bin/phpunit` w/ no errors.